### PR TITLE
docs: fix the documented default for comp in network() and cimDiablo()

### DIFF
--- a/R/cimDiablo.R
+++ b/R/cimDiablo.R
@@ -22,9 +22,10 @@
 #' @param color.Y a character vector of colors to be used for the levels of the
 #' outcome
 #' @param color.blocks a character vector of colors to be used for the blocks
-#' @param comp positive integer. The similarity matrix is computed based on the
-#' variables selected on those specified components. See example. Defaults to
-#' \code{comp = 1}.
+#' @param comp positive integer or vector of positive integers. The similarity
+#' matrix is computed based on the variables selected on those specified
+#' components. See example. Defaults to \code{comp = 1:ncomp}, i.e. all
+#' components are used.
 #' @param margins numeric vector of length two containing the margins (see
 #' \code{\link{par}(mar)}) for column and row names respectively.
 #' @param legend.position position of the legend, one of "bottomright",

--- a/R/network.R
+++ b/R/network.R
@@ -91,7 +91,8 @@
 #' \code{mixo_spls}, \code{splsda}, \code{rcc}, \code{sgcca}, \code{rgcca}, 
 #' \code{sgccda}.
 #' @param comp atomic or vector of positive integers. The components to
-#' adequately account for the data association. Defaults to \code{comp = 1}.
+#' adequately account for the data association. Defaults to \code{comp = 1:ncomp},
+#' i.e. all components are used.
 #' @param cutoff numeric value between \code{0} and \code{1}. The tuning
 #' threshold for the relevant associations network (see Details).
 #' @param row.names,col.names character vector containing the names of \eqn{X}-

--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 
 [![download](http://www.bioconductor.org/shields/downloads/release/mixOmics.svg)](https://bioconductor.org/packages/stats/bioc/mixOmics)
 [![R build
-status](https://github.com/mixOmicsteam/mixOmics/workflows/R-CMD-check.yml/badge.svg)](https://github.com/mixOmicsteam/mixOmics/actions)
-[![](https://img.shields.io/github/last-commit/mixOmicsTeam/mixOmics.svg)](https://github.com/mixOmicsTeam/mixOmics/commits/master)
-[![](https://codecov.io/gh/mixOmicsTeam/mixOmics/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mixOmicsTeam/mixOmics)
+status](https://github.com/mixOmics-org/mixOmics/workflows/R-CMD-check.yml/badge.svg)](https://github.com/mixOmics-org/mixOmics/actions)
+[![](https://img.shields.io/github/last-commit/mixOmics-org/mixOmics.svg)](https://github.com/mixOmics-org/mixOmics/commits/master)
+[![](https://codecov.io/gh/mixOmics-org/mixOmics/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mixOmics-org/mixOmics)
 [![license](https://img.shields.io/badge/license-GPL%20(%3E=%202)-lightgrey.svg)](https://choosealicense.com/)
 [![dependencies](http://bioconductor.org/shields/dependencies/release/mixOmics.svg)](http://bioconductor.org/packages/release/bioc/html/mixOmics.html#since)
 
-![](http://mixomics.org/wp-content/uploads/2019/07/MixOmics-Logo-1.png)
+![](https://raw.githubusercontent.com/mixOmics-org/.github/main/profile/assets/mixomics-logo.svg)
 
 This repository contains the `R` package which is [hosted on
 Bioconductor](http://bioconductor.org/packages/release/bioc/html/mixOmics.html)
-and our development `GitHub` versions. Go to www.mixomics.org for
+and our development `GitHub` versions. Go to <https://mixomics.org> for
 information on how to use mixOmics.
 
 ## Installation
@@ -55,7 +55,7 @@ testing.
 install.packages("devtools")
 
 ## install latest github version of mixOmics
-devtools::install_github("mixOmicsTeam/mixOmics")
+devtools::install_github("mixOmics-org/mixOmics")
 ```
 
 ### From Docker container
@@ -158,7 +158,7 @@ docker stop f14b0bc28326
 ## Contribution
 
 We welcome community contributions concordant with [our code of
-conduct](https://github.com/mixOmicsTeam/mixOmics/blob/master/CODE_OF_CONDUCT.md).
+conduct](https://github.com/mixOmics-org/mixOmics/blob/master/CODE_OF_CONDUCT.md).
 We strongly recommend adhering to [Bioconductor’s coding
 guide](https://bioconductor.org/developers/how-to/coding-style/) for
 software consistency if you wish to contribute to `mixOmics` R codes.

--- a/man/cimDiablo.Rd
+++ b/man/cimDiablo.Rd
@@ -32,9 +32,10 @@ outcome}
 
 \item{color.blocks}{a character vector of colors to be used for the blocks}
 
-\item{comp}{positive integer. The similarity matrix is computed based on the
-variables selected on those specified components. See example. Defaults to
-\code{comp = 1}.}
+\item{comp}{positive integer or vector of positive integers. The similarity
+matrix is computed based on the variables selected on those specified
+components. See example. Defaults to \code{comp = 1:ncomp}, i.e. all
+components are used.}
 
 \item{margins}{numeric vector of length two containing the margins (see
 \code{\link{par}(mar)}) for column and row names respectively.}

--- a/man/network.Rd
+++ b/man/network.Rd
@@ -46,7 +46,8 @@ an object from one of the following models: \code{mix_pls}, \code{plsda},
 \code{sgccda}.}
 
 \item{comp}{atomic or vector of positive integers. The components to
-adequately account for the data association. Defaults to \code{comp = 1}.}
+adequately account for the data association. Defaults to \code{comp = 1:ncomp},
+i.e. all components are used.}
 
 \item{blocks}{a vector indicating the block variables to display.}
 


### PR DESCRIPTION
## What this PR does

This is a docs only change. Nothing in the code behaviour changes.

The help pages for `network()` and `cimDiablo()` said that `comp` defaults to 1. That is not what the code does. Both functions set `comp = NULL` and then fall back to all components, which is `1:ncomp`. This PR fixes the help text so it matches the code.

It also notes that `comp` in `cimDiablo()` can be a vector of integers, not just a single integer.

While I was here I updated the README so the GitHub links point to the new `mixOmics-org` organisation instead of `mixOmicsTeam`. The logo now comes from the org profile repo, and the website link is a proper https link.

## Files changed

- `R/network.R` and `man/network.Rd`: the comp default is now documented as `1:ncomp`
- `R/cimDiablo.R` and `man/cimDiablo.Rd`: same fix, plus a note that comp can be a vector
- `README.md`: GitHub org links, logo URL, and website link

## How to check

Open the help page for `network` or `cimDiablo` and read the `comp` entry. Then look at the source. In `network.R` the fallback is around line 309 and in `cimDiablo.R` it is around line 106. Both set comp to `1:ncomp` when nothing is passed in.

No tests needed since only comments, help files, and the README changed.
