### PR TITLE
Fix circosPlot() error when a block has a single selected variable

### DIFF
--- a/R/circosPlot.R
+++ b/R/circosPlot.R
@@ -263,7 +263,7 @@ circosPlot <- function(object, ...) UseMethod('circosPlot')
         keepA = lapply(object$loadings, function(i)
             apply(abs(i)[, comp, drop = FALSE], 1, sum) > 0)
         cord = mapply(function(x, y, keep){
-            cor(x[, keep], y[, comp], use = "pairwise")
+            cor(x[, keep, drop = FALSE], y[, comp, drop = FALSE], use = "pairwise")
         }, x=X, y=object$variates,
         keep = keepA, SIMPLIFY = FALSE)
         

--- a/tests/testthat/test-circsPlot.R
+++ b/tests/testthat/test-circsPlot.R
@@ -62,3 +62,27 @@ test_that("circosPlot works when using the indY parameter", code = {
     expect_is(cp_res, "matrix")
 })
 
+
+test_that("circosPlot works with comp = 1 when a block has a single selected variable", code = {
+    # Check that selecting a single variable preserves its name and avoids indexing errors.
+    data("breast.TCGA")
+    data = list(mrna = breast.TCGA$data.train$mrna,
+                mirna = breast.TCGA$data.train$mirna,
+                protein = breast.TCGA$data.train$protein)
+
+    list.keepX = list(mrna = c(10, 10), mirna = c(1, 10), protein = c(10, 10))
+    TCGA.block.splsda = block.splsda(X = data, Y = breast.TCGA$data.train$subtype,
+                                     ncomp = 2, keepX = list.keepX, design = 'full')
+
+    cp_res <- circosPlot(TCGA.block.splsda, comp = 1, cutoff = 0.5)
+
+    expect_is(cp_res, "matrix")
+    # one row/column per variable selected on comp 1 across all blocks
+    expect_equal(ncol(cp_res), sum(sapply(list.keepX, `[`, 1)))
+    # preserve every selected feature name in block and input-variable order
+    expected.names <- unlist(lapply(TCGA.block.splsda$loadings[names(data)],
+                                   function(x) rownames(x)[x[, 1] != 0]),
+                             use.names = FALSE)
+    expect_identical(rownames(cp_res), expected.names)
+    expect_identical(colnames(cp_res), expected.names)
+})


### PR DESCRIPTION
# PR addressing Issue #402

Closes #402

## Summary

`circosPlot()` failed with `subscript out of bounds` when a block had a single selected variable on the chosen component (e.g. `comp = 1` with `keepX = list(mrna = c(10, 10), mirna = c(1, 10), protein = c(10, 10))`). This reproduces the error reported on the [user forum](https://mixomics-users.discourse.group/t/circus-plot-cannot-choose-only-one-component/1424).

## Cause and fix

In `R/circosPlot.R`, `cor(x[, keep], y[, comp], use = "pairwise")` dropped `x[, keep]` to a vector when only one variable was selected, losing its column name, so the later indexing by `colnames(simMat)` failed. The fix adds `drop = FALSE` to both subsets so the correlation matrix keeps its dimensions and names.

## Tests

Added a test in `test-circsPlot.R` that fits the `breast.TCGA` model from the issue, calls `circosPlot(comp = 1)`, and checks that the returned similarity matrix has one row and column per selected variable (21) with all feature names preserved in block order. Existing `circosPlot` tests are unchanged.
